### PR TITLE
Use factories instead of dynamic di

### DIFF
--- a/Command/VhostDefineCommand.php
+++ b/Command/VhostDefineCommand.php
@@ -2,11 +2,9 @@
 
 namespace Ola\RabbitMqAdminToolkitBundle\Command;
 
-use Ola\RabbitMqAdminToolkitBundle\DependencyInjection\OlaRabbitMqAdminToolkitExtension;
 use Ola\RabbitMqAdminToolkitBundle\VhostConfiguration;
 use Ola\RabbitMqAdminToolkitBundle\VhostConfigurationFactory;
 use Ola\RabbitMqAdminToolkitBundle\VhostHandler;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Command/VhostDefineCommand.php
+++ b/Command/VhostDefineCommand.php
@@ -4,6 +4,7 @@ namespace Ola\RabbitMqAdminToolkitBundle\Command;
 
 use Ola\RabbitMqAdminToolkitBundle\DependencyInjection\OlaRabbitMqAdminToolkitExtension;
 use Ola\RabbitMqAdminToolkitBundle\VhostConfiguration;
+use Ola\RabbitMqAdminToolkitBundle\VhostConfigurationFactory;
 use Ola\RabbitMqAdminToolkitBundle\VhostHandler;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -16,7 +17,7 @@ class VhostDefineCommand extends Command
 {
     protected static $defaultName = 'rabbitmq:vhost:define';
 
-    private ContainerInterface $serviceLocator;
+    private VhostConfigurationFactory $vhostConfigurationFactory;
 
     private array $vhostList;
 
@@ -25,14 +26,14 @@ class VhostDefineCommand extends Command
     private bool $silentFailure;
 
     public function __construct(
-        ContainerInterface $serviceLocator,
+        VhostConfigurationFactory $vhostConfigurationFactory,
         array $vhostList,
         VhostHandler $vhostHandler,
         bool $silentFailure
     ) {
         parent::__construct();
 
-        $this->serviceLocator = $serviceLocator;
+        $this->vhostConfigurationFactory = $vhostConfigurationFactory;
         $this->vhostList = $vhostList;
         $this->vhostHandler = $vhostHandler;
         $this->silentFailure = $silentFailure;
@@ -104,19 +105,7 @@ class VhostDefineCommand extends Command
      */
     private function getVhostConfiguration(string $vhost): VhostConfiguration
     {
-        $serviceName = sprintf(
-            OlaRabbitMqAdminToolkitExtension::VHOST_MANAGER_SERVICE_TEMPLATE,
-            $vhost
-        );
-
-        if (!$this->serviceLocator->has($serviceName)) {
-            throw new \InvalidArgumentException(sprintf(
-                'No configuration service found for vhost : "%s"',
-                $vhost
-            ));
-        }
-
-        return $this->serviceLocator->get($serviceName);
+        return $this->vhostConfigurationFactory->getVhostConfiguration($vhost);
     }
 
     /**

--- a/DependencyInjection/OlaRabbitMqAdminToolkitExtension.php
+++ b/DependencyInjection/OlaRabbitMqAdminToolkitExtension.php
@@ -2,13 +2,8 @@
 
 namespace Ola\RabbitMqAdminToolkitBundle\DependencyInjection;
 
-use Ola\RabbitMqAdminToolkitBundle\ClientFactory;
-use Ola\RabbitMqAdminToolkitBundle\VhostConfiguration;
-use RabbitMq\ManagementApi\Client;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -33,54 +28,11 @@ class OlaRabbitMqAdminToolkitExtension extends Extension
 
         $container->setParameter(sprintf(self::PARAMETER_TEMPLATE, 'vhost_list'), array_keys($config['vhosts']));
         $container->setParameter(sprintf(self::PARAMETER_TEMPLATE, 'silent_failure'), $config['silent_failure']);
-
-        $this->loadConnections($config['connections'], $container);
-        $this->loadVhostManagers($config['vhosts'], $container, $config['delete_allowed']);
+        $container->setParameter(sprintf(self::PARAMETER_TEMPLATE, 'connections'), $config['connections']);
+        $container->setParameter(sprintf(self::PARAMETER_TEMPLATE, 'vhosts'), $config['vhosts']);
+        $container->setParameter(sprintf(self::PARAMETER_TEMPLATE, 'delete_allowed'), $config['delete_allowed']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
-    }
-
-    /**
-     * @param array $connections
-     * @param ContainerBuilder $container
-     */
-    private function loadConnections(array $connections, ContainerBuilder $container): void
-    {
-        foreach ($connections as $name => $uri) {
-            $parsedUri = parse_url($uri);
-
-            $definition = new Definition(Client::class, [
-                $parsedUri['scheme'],
-                $parsedUri['host'],
-                $parsedUri['user'],
-                $parsedUri['pass'],
-                $parsedUri['port'] ?? 80
-            ]);
-
-            $definition->setFactory([ClientFactory::class, 'getClient']); // necessary to have the exception handling
-            $definition->setPublic(true);
-            $container->setDefinition(sprintf(self::CONNECTION_SERVICE_TEMPLATE, $name), $definition);
-        }
-    }
-
-    /**
-     * @param array $vhosts
-     * @param ContainerBuilder $container
-     * @param bool $deleteAllowed
-     */
-    private function loadVhostManagers(array $vhosts, ContainerBuilder $container, bool $deleteAllowed): void
-    {
-        foreach ($vhosts as $name => $vhost) {
-            $definition = new Definition(VhostConfiguration::class, [
-                new Reference(sprintf(self::CONNECTION_SERVICE_TEMPLATE, $vhost['connection'])),
-                !empty($vhost['name']) ? $vhost['name'] : $name,
-                $vhost,
-                $deleteAllowed
-            ]);
-            $definition->setPublic(true);
-            $definition->addTag('ola_rabbit_mq_admin_toolkit.vhost_configuration');
-            $container->setDefinition(sprintf(self::VHOST_MANAGER_SERVICE_TEMPLATE, $name), $definition);
-        }
     }
 }

--- a/DependencyInjection/OlaRabbitMqAdminToolkitExtension.php
+++ b/DependencyInjection/OlaRabbitMqAdminToolkitExtension.php
@@ -15,8 +15,6 @@ use Symfony\Component\DependencyInjection\Loader;
 class OlaRabbitMqAdminToolkitExtension extends Extension
 {
     const PARAMETER_TEMPLATE = 'ola_rabbit_mq_admin_toolkit.%s';
-    const CONNECTION_SERVICE_TEMPLATE = 'ola_rabbit_mq_admin_toolkit.connection.%s';
-    const VHOST_MANAGER_SERVICE_TEMPLATE = 'ola_rabbit_mq_admin_toolkit.configuration.%s';
 
     /**
      * {@inheritdoc}

--- a/Exception/ConfigurationNotFoundException.php
+++ b/Exception/ConfigurationNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ola\RabbitMqAdminToolkitBundle\Exception;
+
+class ConfigurationNotFoundException extends \Exception
+{
+}

--- a/Exception/ConnectionNotFoundException.php
+++ b/Exception/ConnectionNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ola\RabbitMqAdminToolkitBundle\Exception;
+
+class ConnectionNotFoundException extends \Exception
+{
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -3,6 +3,13 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="Ola\RabbitMqAdminToolkitBundle\ClientFactory" />
+        <service id="Ola\RabbitMqAdminToolkitBundle\VhostConfigurationFactory">
+            <argument type="service" id="Ola\RabbitMqAdminToolkitBundle\ClientFactory" />
+            <argument>%ola_rabbit_mq_admin_toolkit.delete_allowed%</argument>
+            <argument>%ola_rabbit_mq_admin_toolkit.connections%</argument>
+            <argument>%ola_rabbit_mq_admin_toolkit.vhosts%</argument>
+        </service>
         <service id="Ola\RabbitMqAdminToolkitBundle\VhostHandler">
             <argument type="service" id="Ola\RabbitMqAdminToolkitBundle\Manager\VhostManager"/>
             <argument type="service" id="Ola\RabbitMqAdminToolkitBundle\Manager\PermissionManager"/>
@@ -19,7 +26,7 @@
         <service id="Ola\RabbitMqAdminToolkitBundle\Manager\BindingManager" />
         <service id="Ola\RabbitMqAdminToolkitBundle\Command\VhostDefineCommand">
             <tag name="console.command" />
-            <argument type="tagged_locator" tag="ola_rabbit_mq_admin_toolkit.vhost_configuration" />
+            <argument type="service" id="Ola\RabbitMqAdminToolkitBundle\VhostConfigurationFactory" />
             <argument>%ola_rabbit_mq_admin_toolkit.vhost_list%</argument>
             <argument type="service" id="Ola\RabbitMqAdminToolkitBundle\VhostHandler" />
             <argument>%ola_rabbit_mq_admin_toolkit.silent_failure%</argument>

--- a/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
+++ b/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
@@ -17,75 +17,81 @@ class OlaRabbitMqAdminToolkitExtensionTest extends AbstractExtensionTestCase
 
     public function test_load_successfull()
     {
-        $this->load([
-            'delete_allowed' => true,
-            'connections' => [
-                'default' => 'http://user:password@localhost',
-            ],
-            'vhosts' => [
-                'test' => [
-                    'name' => '/test',
-                    'connection' => 'default',
-                    'permissions' => [
-                        'lafourchette' => NULL,
+        $connections = [
+            'default' => 'http://user:password@localhost',
+        ];
+        $vhosts = [
+            'test' => [
+                'name' => '/test',
+                'connection' => 'default',
+                'permissions' => [
+                    'lafourchette' => NULL,
+                ],
+                'exchanges' => [
+                    'exchange.a' => NULL,
+                    'exchange.b' => [
+                        'type' => 'direct',
                     ],
-                    'exchanges' => [
-                        'exchange.a' => NULL,
-                        'exchange.b' => [
-                            'type' => 'direct',
-                        ],
-                        'exchange.c' => NULL,
-                    ],
-                    'queues' => [
-                        'queue.a.sharded' => [
-                            'name' => 'queue.a.{modulus}',
-                            'modulus' => 10,
-                            'bindings' => [
-                                [
-                                    'exchange' => 'exchange.a',
-                                    'routing_key' => 'a.{modulus}.#',
-                                ],
-                                [
-                                    'exchange' => 'exchange.b',
-                                    'routing_key' => 'b.#',
-                                ],
+                    'exchange.c' => NULL,
+                ],
+                'queues' => [
+                    'queue.a.sharded' => [
+                        'name' => 'queue.a.{modulus}',
+                        'modulus' => 10,
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.{modulus}.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.b',
+                                'routing_key' => 'b.#',
                             ],
                         ],
-                        'queue.b.{modulus}' => [
-                            'bindings' => [
-                                [
-                                    'exchange' => 'exchange.a',
-                                    'routing_key' => 'a.#',
-                                ],
-                                [
-                                    'exchange' => 'exchange.b',
-                                    'routing_key' => 'b.{modulus}.#',
-                                ],
-                                [
-                                    'exchange' => 'exchange.c',
-                                    'routing_key' => 'c.#',
-                                ],
+                    ],
+                    'queue.b.{modulus}' => [
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.b',
+                                'routing_key' => 'b.{modulus}.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.c',
+                                'routing_key' => 'c.#',
                             ],
                         ],
-                        'queue.c' => [
-                            'bindings' => [
-                                [
-                                    'exchange' => 'exchange.a',
-                                    'routing_key' => 'a.#',
-                                ],
-                                [
-                                    'exchange' => 'exchange.c',
-                                    'routing_key' => 'c.#',
-                                ],
+                    ],
+                    'queue.c' => [
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.c',
+                                'routing_key' => 'c.#',
                             ],
                         ],
                     ],
                 ],
             ],
+        ];
+
+        $this->load([
+            'delete_allowed' => true,
+            'connections' => $connections,
+            'vhosts' => $vhosts,
         ]);
-        $this->assertContainerBuilderHasService('ola_rabbit_mq_admin_toolkit.connection.default');
-        $this->assertContainerBuilderHasService('ola_rabbit_mq_admin_toolkit.configuration.test');
+
+        // todo assert new parameters are created
         $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhost_list');
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhosts');
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.connections');
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.delete_allowed');
     }
 
     public function dataProvider_load_failBecauseModulusIsImproperlyDefined(): array

--- a/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
+++ b/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
@@ -87,7 +87,6 @@ class OlaRabbitMqAdminToolkitExtensionTest extends AbstractExtensionTestCase
             'vhosts' => $vhosts,
         ]);
 
-        // todo assert new parameters are created
         $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhost_list');
         $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhosts');
         $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.connections');

--- a/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
+++ b/Tests/DependencyInjection/OlaRabbitMqAdminToolkitExtensionTest.php
@@ -81,16 +81,102 @@ class OlaRabbitMqAdminToolkitExtensionTest extends AbstractExtensionTestCase
             ],
         ];
 
+        $expectedVhosts = [
+            'test' => [
+                'name' => '/test',
+                'connection' => 'default',
+                'permissions' => [
+                    'lafourchette' => [
+                        'configure' => '.*',
+                        'read' => '.*',
+                        'write' => '.*'
+                    ],
+                ],
+                'exchanges' => [
+                    'exchange.a' => [
+                        'name' => 'exchange.a',
+                        'type' => 'topic',
+                        'durable' => true
+                    ],
+                    'exchange.b' => [
+                        'type' => 'direct',
+                        'name' => 'exchange.b',
+                        'durable' => true
+                    ],
+                    'exchange.c' => [
+                        'name' => 'exchange.c',
+                        'type' => 'topic',
+                        'durable' => true
+                    ],
+                ],
+                'queues' => [
+                    'queue.a.sharded' => [
+                        'name' => 'queue.a.{modulus}',
+                        'modulus' => 10,
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.{modulus}.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.b',
+                                'routing_key' => 'b.#',
+                            ],
+                        ],
+                        'durable' => true,
+                        'arguments' => []
+                    ],
+                    'queue.b.{modulus}' => [
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.b',
+                                'routing_key' => 'b.{modulus}.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.c',
+                                'routing_key' => 'c.#',
+                            ],
+                        ],
+                        'name' => 'queue.b.{modulus}',
+                        'durable' => true,
+                        'modulus' => null,
+                        'arguments' => []
+
+                    ],
+                    'queue.c' => [
+                        'bindings' => [
+                            [
+                                'exchange' => 'exchange.a',
+                                'routing_key' => 'a.#',
+                            ],
+                            [
+                                'exchange' => 'exchange.c',
+                                'routing_key' => 'c.#',
+                            ],
+                        ],
+                        'name' => 'queue.c',
+                        'durable' => true,
+                        'modulus' => null,
+                        'arguments' => []
+                    ],
+                ],
+            ],
+        ];
+
         $this->load([
             'delete_allowed' => true,
             'connections' => $connections,
             'vhosts' => $vhosts,
         ]);
 
-        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhost_list');
-        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhosts');
-        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.connections');
-        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.delete_allowed');
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhost_list', ['test']);
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.vhosts', $expectedVhosts);
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.connections', $connections);
+        $this->assertContainerBuilderHasParameter('ola_rabbit_mq_admin_toolkit.delete_allowed', true);
     }
 
     public function dataProvider_load_failBecauseModulusIsImproperlyDefined(): array

--- a/Tests/VhostConfigurationFactoryTest.php
+++ b/Tests/VhostConfigurationFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Ola\RabbitMqAdminToolkitBundle\Tests;
+
+use Ola\RabbitMqAdminToolkitBundle\ClientFactory;
+use Ola\RabbitMqAdminToolkitBundle\Exception\ConfigurationNotFoundException;
+use Ola\RabbitMqAdminToolkitBundle\Exception\ConnectionNotFoundException;
+use Ola\RabbitMqAdminToolkitBundle\VhostConfiguration;
+use Ola\RabbitMqAdminToolkitBundle\VhostConfigurationFactory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class VhostConfigurationFactoryTest extends TestCase
+{
+    private ObjectProphecy $clientFactory;
+
+    private VhostConfigurationFactory $vhostConfigurationFactory;
+
+    public function setUp(): void
+    {
+        $this->clientFactory = $this->prophesize(ClientFactory::class);
+        $this->vhostConfigurationFactory = new VhostConfigurationFactory(
+            $this->clientFactory->reveal(),
+            true,
+            [
+                'default' => 'https://login:pwd@rabbitmq.local:443'
+            ],
+            [
+                'default' => [
+                    'connection' => 'default'
+                ],
+                'with_connection_not_found' => [
+                    'connection' => 'not_found'
+                ]
+            ]
+        );
+    }
+
+    public function testWithVhostNotFound()
+    {
+        $this->expectException(ConfigurationNotFoundException::class);
+        $this->clientFactory->getClient(Argument::cetera())->shouldNotBeCalled();
+
+        $this->vhostConfigurationFactory->getVhostConfiguration('not_found');
+    }
+
+    public function testWithConnectionNotFound()
+    {
+        $this->expectException(ConnectionNotFoundException::class);
+        $this->clientFactory->getClient(Argument::cetera())->shouldNotBeCalled();
+
+        $this->vhostConfigurationFactory->getVhostConfiguration('with_connection_not_found');
+    }
+
+    public function testWithWorkingScenario()
+    {
+        $this
+            ->clientFactory
+            ->getClient(
+                'https',
+                'rabbitmq.local',
+                'login',
+                'pwd',
+                443
+            )->shouldBeCalledTimes(1);
+
+        $result = $this->vhostConfigurationFactory->getVhostConfiguration('default');
+
+        $this->assertInstanceOf(VhostConfiguration::class, $result);
+    }
+}

--- a/VhostConfigurationFactory.php
+++ b/VhostConfigurationFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Ola\RabbitMqAdminToolkitBundle;
+
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\HttpClientDiscovery;
+use RabbitMq\ManagementApi\Client;
+
+class VhostConfigurationFactory
+{
+    private ClientFactory $clientFactory;
+
+    private bool $deleteAllowed;
+
+    private array $connections;
+
+    private array $vhosts;
+
+    public function __construct(ClientFactory $clientFactory, bool $deleteAllowed, array $connections, array $vhosts)
+    {
+        $this->clientFactory = $clientFactory;
+        $this->deleteAllowed = $deleteAllowed;
+        $this->connections = $connections;
+        $this->vhosts = $vhosts;
+    }
+
+    public function getVhostConfiguration(string $vhostName): VhostConfiguration
+    {
+        $vhostConfiguration = $this->vhosts[$vhostName] ?? null;
+        
+        if (null === $vhostConfiguration) {
+            throw new \Exception(sprintf('No vhost configuration found for vhost %s', $vhostConfiguration['name']));
+        }
+        
+        $connectionUri = $this->connections[$vhostConfiguration['connection']] ?? null;
+
+        if (null === $connectionUri) {
+            throw new \Exception(sprintf('No connection found for vhost %s', $vhostConfiguration['name']));
+        }
+
+        $parsedUri = parse_url($connectionUri);
+
+        return new VhostConfiguration(
+            $this->clientFactory->getClient(
+              $parsedUri['scheme'],
+              $parsedUri['host'],
+              $parsedUri['user'],
+              $parsedUri['pass'],
+              $parsedUri['port'] ?? 80
+            ),
+            $vhostConfiguration['name'] ?? $vhostName,
+            $vhostConfiguration,
+            $this->deleteAllowed
+        );
+    }
+}


### PR DESCRIPTION
This VhostConfigurationFactory will be used by the VhostDefineCommand to create all the VhostConfiguration services.
Those services used to be created as container definitions at bundle's injection but have been removed so that the bundle remains as discrete as possible when non used, and doesn't add unnecessary processing during the dependency injection phase, as its purpose is to be used as a one-shot to define the vhosts